### PR TITLE
Avoid adjoint sparse matrix times `Diagonal`

### DIFF
--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -33,7 +33,7 @@ import SciMLBase: u_modified!
 
 @reexport using StaticArrays: SVector
 using SimpleUnPack: @unpack
-using SparseArrays: sparse, issparse
+using SparseArrays: sparse, spdiagm, issparse
 using SummationByPartsOperators: SummationByPartsOperators,
                                  AbstractDerivativeOperator,
                                  PeriodicDerivativeOperator, PeriodicUpwindOperators,

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -33,7 +33,7 @@ import SciMLBase: u_modified!
 
 @reexport using StaticArrays: SVector
 using SimpleUnPack: @unpack
-using SparseArrays: sparse, spdiagm, issparse
+using SparseArrays: sparse, issparse
 using SummationByPartsOperators: SummationByPartsOperators,
                                  AbstractDerivativeOperator,
                                  PeriodicDerivativeOperator, PeriodicUpwindOperators,

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -268,7 +268,7 @@ function assemble_system_matrix!(cache, h, D1, D1mat,
     # is not necessarily perfectly symmetric but only up to
     # round-off errors. We wrap it here to avoid issues with the
     # factorization.
-    return Symmetric(Diagonal(M_h) + D1mat' * spdiagm(M_h3_3) * D1mat)
+    return Symmetric(Diagonal(M_h) + D1mat' * (Diagonal(M_h3_3) * D1mat))
 end
 
 # variable bathymetry

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -268,7 +268,7 @@ function assemble_system_matrix!(cache, h, D1, D1mat,
     # is not necessarily perfectly symmetric but only up to
     # round-off errors. We wrap it here to avoid issues with the
     # factorization.
-    return Symmetric(Diagonal(M_h) + D1mat' * Diagonal(M_h3_3) * D1mat)
+    return Symmetric(Diagonal(M_h) + D1mat' * spdiagm(M_h3_3) * D1mat)
 end
 
 # variable bathymetry

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -264,7 +264,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
        D1 isa FourierDerivativeOperator
         D1_central = D1
         D1mat = sparse(D1_central)
-        minus_MD1betaD1 = D1mat' * Diagonal(M_beta) * D1mat
+        minus_MD1betaD1 = D1mat' * (Diagonal(M_beta) * D1mat)
         system_matrix = let cache = (; D1, M_h, minus_MD1betaD1)
             assemble_system_matrix!(cache, h,
                                     equations, boundary_conditions)
@@ -272,7 +272,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
     elseif D1 isa PeriodicUpwindOperators
         D1_central = D1.central
         D1mat_minus = sparse(D1.minus)
-        minus_MD1betaD1 = D1mat_minus' * Diagonal(M_beta) * D1mat_minus
+        minus_MD1betaD1 = D1mat_minus' * (Diagonal(M_beta) * D1mat_minus)
         system_matrix = let cache = (; D1, M_h, minus_MD1betaD1)
             assemble_system_matrix!(cache, h,
                                     equations, boundary_conditions)
@@ -326,16 +326,16 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
        D1 isa UniformCoupledOperator
         D1_central = D1
         D1mat = sparse(D1_central)
-        minus_MD1betaD1 = sparse(D1mat' * Diagonal(M_beta) *
-                                 D1mat * Pd)[(begin + 1):(end - 1), :]
+        minus_MD1betaD1 = sparse(D1mat' * (Diagonal(M_beta) *
+                                 D1mat * Pd))[(begin + 1):(end - 1), :]
         system_matrix = let cache = (; D1, M_h, minus_MD1betaD1)
             assemble_system_matrix!(cache, h, equations, boundary_conditions)
         end
     elseif D1 isa UpwindOperators
         D1_central = D1.central
         D1mat_minus = sparse(D1.minus)
-        minus_MD1betaD1 = sparse(D1mat_minus' * Diagonal(M_beta) *
-                                 D1mat_minus * Pd)[(begin + 1):(end - 1), :]
+        minus_MD1betaD1 = sparse(D1mat_minus' * (Diagonal(M_beta) *
+                                 D1mat_minus * Pd))[(begin + 1):(end - 1), :]
         system_matrix = let cache = (; D1, M_h, minus_MD1betaD1)
             assemble_system_matrix!(cache, h, equations, boundary_conditions)
         end


### PR DESCRIPTION
Using `Diagonal`slowed down the simulation dramatically as observed in #178. With `spdiagm` this is fixed.
Running serre_green_naghdi_soliton_upwind.jl. on `main`:
```julia
───────────────────────────────────────────────────────────────────────────────────────────
              DispersiveSWE                       Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 3.40s /  99.8%            879MiB /  99.9%    

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
rhs!                              1.62k    3.39s  100.0%  2.09ms    877MiB  100.0%   554KiB
  assembling elliptic operator    1.62k    3.27s   96.4%  2.01ms    584MiB   66.5%   368KiB
  solving elliptic system         1.62k    116ms    3.4%  71.5μs    293MiB   33.4%   185KiB
  hyperbolic terms                1.62k   4.32ms    0.1%  2.66μs     0.00B    0.0%    0.00B
  ~rhs!~                          1.62k    620μs    0.0%   382ns   1.25KiB    0.0%    0.79B
analyze solution                      3    538μs    0.0%   179μs    148KiB    0.0%  49.3KiB
───────────────────────────────────────────────────────────────────────────────────────────
```
This PR (old version with `spdiagm`:
```julia
───────────────────────────────────────────────────────────────────────────────────────────
              DispersiveSWE                       Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 237ms /  97.5%            861MiB /  99.9%    

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
rhs!                              1.62k    229ms   99.3%   141μs    860MiB  100.0%   542KiB
  solving elliptic system         1.62k    118ms   50.9%  72.4μs    293MiB   34.1%   185KiB
  assembling elliptic operator    1.62k    107ms   46.5%  66.1μs    566MiB   65.9%   357KiB
  hyperbolic terms                1.62k   4.10ms    1.8%  2.53μs     0.00B    0.0%    0.00B
  ~rhs!~                          1.62k    515μs    0.2%   317ns   1.25KiB    0.0%    0.79B
analyze solution                      3   1.52ms    0.7%   506μs    150KiB    0.0%  49.9KiB
───────────────────────────────────────────────────────────────────────────────────────────
```
This PR (new version with `Diagonal` and paranthesis):
```julia
───────────────────────────────────────────────────────────────────────────────────────────
              DispersiveSWE                       Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 208ms /  96.6%            778MiB /  99.8%    

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
rhs!                              1.62k    201ms   99.8%   124μs    776MiB  100.0%   490KiB
  solving elliptic system         1.62k    116ms   57.8%  71.7μs    293MiB   37.8%   185KiB
  assembling elliptic operator    1.62k   79.5ms   39.5%  49.0μs    483MiB   62.2%   305KiB
  hyperbolic terms                1.62k   4.20ms    2.1%  2.59μs     0.00B    0.0%    0.00B
  ~rhs!~                          1.62k    703μs    0.3%   433ns   1.25KiB    0.0%    0.79B
analyze solution                      3    487μs    0.2%   162μs    148KiB    0.0%  49.3KiB
───────────────────────────────────────────────────────────────────────────────────────────
```
Fixes #178.