### PR TITLE
use `semidiscretize` from SummationByPartsOperators.jl

### DIFF
--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -44,7 +44,7 @@ using SummationByPartsOperators: SummationByPartsOperators,
                                  periodic_derivative_operator,
                                  derivative_order, integrate, mass_matrix,
                                  scale_by_mass_matrix!
-import SummationByPartsOperators: grid, xmin, xmax
+import SummationByPartsOperators: grid, xmin, xmax, semidiscretize
 using TimerOutputs: TimerOutputs, print_timer, reset_timer!
 @reexport using TrixiBase: trixi_include
 using TrixiBase: TrixiBase, @trixi_timeit, timer


### PR DESCRIPTION
Sometimes, it can be convenient to load everything. Before this PR:

```julia
julia> using DispersiveShallowWater, SummationByPartsOperators

julia> semidiscretize
WARNING: both SummationByPartsOperators and DispersiveShallowWater export "semidiscretize"; uses of it in module Main must be qualified
ERROR: UndefVarError: `semidiscretize` not defined
```

With this change:

```julia
julia> using DispersiveShallowWater, SummationByPartsOperators
Precompiling DispersiveShallowWater finished.
  1 dependency successfully precompiled in 3 seconds. 154 already precompiled.

julia> semidiscretize
semidiscretize (generic function with 3 methods)
```
