### PR TITLE
change default parameter set for Svärd-Kalisch equations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,10 +24,10 @@ for human readability.
 
 - Add `LinearDispersionRelation` and documentation about dispersion ([#168]).
 - Reflecting boundary conditions are added for the Svärd-Kalisch equations with `alpha = gamma = 0` ([#166]).
-- Fix a bug in the upwind discretization of the `SvärdKalischEquations1D`.
+- Fix a bug in the upwind discretization of the `SvaerdKalischEquations1D`.
 - Use OrdinaryDiffEqTsit5.jl and OrdinaryDiffEqLowStorageRK.jl instead of OrdinaryDiffEq.jl in all examples to
   reduce latency ([#163]).
-- Allow Fourier and periodic rational derivative operators for `BBMBBMEquations1D` and `SvärdKalischEquations1D` ([#154]).
+- Allow Fourier and periodic rational derivative operators for `BBMBBMEquations1D` and `SvaerdKalischEquations1D` ([#154]).
 - Add `BBMEquation1D` ([#150]).
 
 ## Changes when updating to v0.5 from v0.4.x
@@ -50,7 +50,7 @@ for human readability.
 - The `HyperbolicSerreGreenNaghdiEquations1D` were added for different types of bathymetry ([#139]).
 - The abstract interface `AbstractShallowWaterEquations` was added to unify several
   systems such as the `SerreGreenNaghdiEquations1D`, the `BBMBBMEquations1D`, and the
-  `SvärdKalischEquations1D` ([#127]).
+  `SvaerdKalischEquations1D` ([#127]).
 - A new conversion function `prim2phys` was introduced, defaulting to `prim2prim`. `prim2phys` is the default conversion function for plotting.
 
 ## Changes when updating to v0.4 from v0.3.x

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,14 @@ DispersiveShallowWater.jl follows the interpretation of
 used in the Julia ecosystem. Notable changes will be documented in this file
 for human readability.
 
+
+## Changes when updating to v0.7 from v0.6.x
+
+#### Changed
+
+- The default parameters of the `SvaerdKalischEquations1D` changed from
+  `alpha = 0.0, beta = 0.2308939393939394, gamma = 0.04034343434343434` to `alpha = 0.0, beta = 1/3, gamma = 0.0` ([#196]).
+
 ## Changes in the v0.6 lifecycle
 
 #### Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ for human readability.
 
 #### Added
 
+- Support source terms for `SerreGreenNaghdiEquations1D` ([#180], [#186]).
 - Add initial support for ForwardDiff.jl for `HyperbolicSerreGreenNaghdiEquations1D` and
   `DispersiveShallowWater.jacobian` ([#185]).
 

--- a/docs/src/dispersion.md
+++ b/docs/src/dispersion.md
@@ -50,7 +50,8 @@ bbm = BBMEquation1D(; gravity = g, eta0 = eta0, D = h0)
 c_bbm = wave_speed.(disp_rel, bbm, k; normalize = true)
 plot!(k, c_bbm, label = "BBM")
 
-sk = SvaerdKalischEquations1D(; gravity = g, eta0 = eta0)
+sk = SvaerdKalischEquations1D(; gravity = g, eta0 = eta0,
+                              alpha = 0.0, beta = 0.2308939393939394, gamma = 0.04034343434343434)
 c_sk = wave_speed.(disp_rel, sk, k; normalize = true)
 plot!(k, c_sk, label = "Svärd-Kalisch")
 

--- a/docs/src/dispersion.md
+++ b/docs/src/dispersion.md
@@ -50,6 +50,7 @@ bbm = BBMEquation1D(; gravity = g, eta0 = eta0, D = h0)
 c_bbm = wave_speed.(disp_rel, bbm, k; normalize = true)
 plot!(k, c_bbm, label = "BBM")
 
+# Optimized set 4 in the preprint
 sk = SvaerdKalischEquations1D(; gravity = g, eta0 = eta0,
                               alpha = 0.0, beta = 0.2308939393939394, gamma = 0.04034343434343434)
 c_sk = wave_speed.(disp_rel, sk, k; normalize = true)

--- a/src/dispersion_relation.jl
+++ b/src/dispersion_relation.jl
@@ -92,7 +92,7 @@ end
 # - Magnus Svärd, Henrik Kalisch (2023)
 #   A novel energy-bounded Boussinesq model and a well-balanced and stable numerical discretization
 #   [arXiv: 2302.09924](https://arxiv.org/abs/2302.09924)
-function (disp_rel::LinearDispersionRelation)(equations::SvärdKalischEquations1D, k)
+function (disp_rel::LinearDispersionRelation)(equations::SvaerdKalischEquations1D, k)
     h0 = disp_rel.ref_height
     g = gravity(equations)
     c0 = sqrt(g * h0)

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -1,7 +1,6 @@
 @doc raw"""
-    SvaerdKalischEquations1D(; bathymetry_type = bathymetry_variable,
-                             gravity, eta0 = 0.0, alpha = 0.0,
-                             beta = 0.2308939393939394, gamma = 0.04034343434343434)
+    SvaerdKalischEquations1D(; bathymetry_type = bathymetry_variable, gravity,
+                             eta0 = 0.0, alpha = 0.0, beta = 1/3, gamma = 0.0)
 
 Dispersive system by Svärd and Kalisch (2023) in one spatial dimension. The equations for variable bathymetry
 are given in conservative variables by
@@ -63,9 +62,8 @@ Same as [`SvaerdKalischEquations1D`](@ref).
 """
 const SvärdKalischEquations1D = SvaerdKalischEquations1D
 
-function SvaerdKalischEquations1D(; bathymetry_type = bathymetry_variable,
-                                  gravity, eta0 = 0.0, alpha = 0.0,
-                                  beta = 0.2308939393939394, gamma = 0.04034343434343434)
+function SvaerdKalischEquations1D(; bathymetry_type = bathymetry_variable, gravity,
+                                  eta0 = 0.0, alpha = 0.0, beta = 1 / 3, gamma = 0.0)
     SvaerdKalischEquations1D(bathymetry_type, gravity, eta0, alpha, beta, gamma)
 end
 

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -29,7 +29,7 @@ Currently, the equations only support a general variable bathymetry, see [`bathy
 
 `SvärdKalischEquations1D` is an alias for `SvaerdKalischEquations1D`.
 
-The equations by Svärd and Kalisch are presented and analyzed in Svärd and Kalisch (2023).
+The equations by Svärd and Kalisch are presented and analyzed in Svärd and Kalisch (2025).
 The semidiscretization implemented here conserves
 - the total water mass (integral of ``h``) as a linear invariant
 - the total momentum (integral of ``h v``) as a nonlinear invariant for flat bathymetry
@@ -38,9 +38,10 @@ The semidiscretization implemented here conserves
 for periodic boundary conditions (see Lampert, Ranocha).
 Additionally, it is well-balanced for the lake-at-rest stationary solution, see Lampert and Ranocha (2024).
 
-- Magnus Svärd, Henrik Kalisch (2023)
+- Magnus Svärd, Henrik Kalisch (2025)
   A novel energy-bounded Boussinesq model and a well-balanced and stable numerical discretization
-  [arXiv: 2302.09924](https://arxiv.org/abs/2302.09924)
+  [arXiv: 2302.09924](https://arxiv.org/abs/2302.09924),
+  [DOI: 10.1016/j.jcp.2024.113516](https://doi.org/10.1016/j.jcp.2024.113516)
 - Joshua Lampert, Hendrik Ranocha (2024)
   Structure-Preserving Numerical Methods for Two Nonlinear Systems of Dispersive Wave Equations
   [DOI: 10.48550/arXiv.2402.16669](https://doi.org/10.48550/arXiv.2402.16669)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -430,7 +430,10 @@ end
     for (i, equations) in enumerate((EulerEquations1D(gravity = g),
                                      BBMEquation1D(gravity = g),
                                      BBMBBMEquations1D(gravity = g),
-                                     SvärdKalischEquations1D(gravity = g),
+                                     SvaerdKalischEquations1D(gravity = g,
+                                                              alpha = 0.0,
+                                                              beta = 0.2308939393939394,
+                                                              gamma = 0.04034343434343434),
                                      SerreGreenNaghdiEquations1D(gravity = g)))
         @test isapprox(disp_rel(equations, k), frequencies[i])
         @test isapprox(wave_speed(disp_rel, equations, k), wave_speeds[i])


### PR DESCRIPTION
This changes the default parameter set to set 5, which is isotropic and the one in the published paper of Svärd and Kalisch. I also added the reference to the published version of their paper.
Closes #192.