### PR TITLE
Reducing allocations in relaxation

### DIFF
--- a/src/callbacks_step/relaxation.jl
+++ b/src/callbacks_step/relaxation.jl
@@ -68,151 +68,51 @@ end
     gamma_hi = 3 * one(tnew) / 2
 
     @unpack tmp1 = semi.cache # of size N
-    tmp222 = similar(qold) # of size nvariables * N
+    tmp2 = similar(qold) # of size nvariables * N
     # @unpack tmp222 = semi.cache # of size nvariables * N and ArrayPartition
 
-
     function relaxation_functional(tmp1, q, semi)
         return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
     end
 
-    function convex_combination!(tmp222, gamma, old, new)
-        @.. tmp222 = old + gamma * (new - old)
+    function convex_combination(gamma, told, tnew) # for scalars
+        return @.. told + gamma * (tnew - told)
+    end
+
+    function convex_combination!(tmp2, gamma, uold, unew) # for arrays
+        @.. tmp2 = uold + gamma * (unew - uold)
         return nothing
-    end
-
-    function convex_combination(gamma, old, new)
-        return @.. old + gamma * (new - old)
-    end
-
-    function root(g)
-        convex_combination!(tmp222, g, qold, qnew)
-        return (relaxation_functional(tmp1, tmp222 ,semi) - energy_old)
-    end
-
-    energy_old = relaxation_functional(tmp1, qold, semi)
-
-    @trixi_timeit timer() "relaxation" begin
-        convex_combination!(tmp222, gamma_lo, qold, qnew)
-        val1 = relaxation_functional(tmp1, tmp222, semi) - energy_old
-
-        convex_combination!(tmp222, gamma_hi, qold, qnew)
-        val2 = relaxation_functional(tmp1, tmp222, semi) - energy_old
-
-        if (val1 * val2) > 0
-            terminate_integration = true
-        else
-            gamma = find_zero(root, (gamma_lo, gamma_hi), AlefeldPotraShi())
-        end
-
-        if gamma < eps(typeof(gamma))
-            terminate_integration = true
-        end
-
- 
-        convex_combination!(tmp222, gamma, qold, qnew)
-        DiffEqBase.set_u!(integrator, tmp222)
-
-        if !isapprox(tnew, first(integrator.opts.tstops))
-
-            # convex_combination!(tmp222, gamma, told, tnew)
-            
-            tgamma = convex_combination(gamma, told, tnew)
-            DiffEqBase.set_t!(integrator, tgamma)
-        end
-
-        if terminate_integration
-            terminate!(integrator)
-        end
-    end
-    return nothing
-end
-
-
-
-#= This method is called as callback during the time integration.
-@inline function (relaxation_callback::RelaxationCallback)(integrator)
-    semi = integrator.p
-    told = integrator.tprev
-    qold = integrator.uprev
-    tnew = integrator.t
-    qnew = integrator.u
-
-    terminate_integration = false
-    gamma_lo = one(tnew) / 2
-    gamma_hi = 3 * one(tnew) / 2
-
-    @unpack tmp1 = semi.cache # of size N
-    @unpack tmp222 = semi.cache # of size nvariables * N
-    tmp2 = tmp222
-    tmp3 = similar(tmp2)
-
-
-
-    function relaxation_functional(tmp1, q, semi)
-        return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
-    end
-
-    function convex_combination!(tmp2, gamma, old, new)
-        @. tmp2 = old + gamma * (new - old)
-        return nothing
-    end
-
-    function convex_combination(gamma, old, new)
-        return @.. old + gamma * (new - old)
     end
 
     function root(g)
         convex_combination!(tmp2, g, qold, qnew)
-        return (relaxation_functional(tmp1, tmp2 ,semi) - energy_old)
-    end
-
-    function relaxation_functional2(q, semi)
-        @unpack tmp1 = semi.cache
-        return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
+        return (relaxation_functional(tmp1, tmp2, semi) - energy_old)
     end
 
     energy_old = relaxation_functional(tmp1, qold, semi)
 
     @trixi_timeit timer() "relaxation" begin
+        convex_combination!(tmp2, gamma_lo, qold, qnew)
+        val1 = relaxation_functional(tmp1, tmp2, semi) - energy_old
 
         convex_combination!(tmp2, gamma_hi, qold, qnew)
-        val2 = relaxation_functional2(tmp2, semi) - energy_old
-
-        convex_combination!(tmp3, gamma_lo, qold, qnew)
-        val1 = relaxation_functional2(tmp3, semi) - energy_old
-
-        
-        teststs = 
-        val1_dif = relaxation_functional2(convex_combination(gamma_lo, qold, qnew), semi) - energy_old
-        val2_dif = relaxation_functional2(convex_combination(gamma_hi, qold, qnew), semi) -energy_old
-
-        @show val1
-        @show val1_dif
-        @show val2
-        @show val2_dif
-
+        val2 = relaxation_functional(tmp1, tmp2, semi) - energy_old
 
         if (val1 * val2) > 0
             terminate_integration = true
         else
             gamma = find_zero(root, (gamma_lo, gamma_hi), AlefeldPotraShi())
-            @show gamma
         end
 
         if gamma < eps(typeof(gamma))
             terminate_integration = true
         end
 
- 
         convex_combination!(tmp2, gamma, qold, qnew)
         DiffEqBase.set_u!(integrator, tmp2)
 
         if !isapprox(tnew, first(integrator.opts.tstops))
-
-            # convex_combination!(tmp2, gamma, told, tnew)
-
-            tgamma = convex_combination(gamma, told, tnew)
+            tgamma = convex_combination(gamma, told, tnew) # scalar combination
             DiffEqBase.set_t!(integrator, tgamma)
         end
 
@@ -220,7 +120,5 @@ end
             terminate!(integrator)
         end
     end
-    @show "einmal durch"
     return nothing
 end
-=#

--- a/src/callbacks_step/relaxation.jl
+++ b/src/callbacks_step/relaxation.jl
@@ -68,51 +68,49 @@ end
     gamma_hi = 3 * one(tnew) / 2
 
     @unpack tmp1 = semi.cache # of size N
-    tmp2 = similar(qold) # of size nvariables * N
-    # @unpack tmp222 = semi.cache # of size nvariables * N and ArrayPartition
+    @unpack tmp_partitioned = semi.cache # of size nvariables * N and ArrayPartition
 
     function relaxation_functional(tmp1, q, semi)
         return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
     end
 
-    function convex_combination(gamma, told, tnew) # for scalars
-        return @.. told + gamma * (tnew - told)
-    end
-
-    function convex_combination!(tmp2, gamma, uold, unew) # for arrays
-        @.. tmp2 = uold + gamma * (unew - uold)
+    function convex_combination!(tmp_partitioned, gamma, uold, unew) # for arrays
+        @.. tmp_partitioned = uold + gamma * (unew - uold)
         return nothing
-    end
-
-    function root(g)
-        convex_combination!(tmp2, g, qold, qnew)
-        return (relaxation_functional(tmp1, tmp2, semi) - energy_old)
     end
 
     energy_old = relaxation_functional(tmp1, qold, semi)
 
-    @trixi_timeit timer() "relaxation" begin
-        convex_combination!(tmp2, gamma_lo, qold, qnew)
-        val1 = relaxation_functional(tmp1, tmp2, semi) - energy_old
+    # define the root function
+    function root(g, tmp1, tmp_partitioned, qold, qnew, energy_old)
+        convex_combination!(tmp_partitioned, g, qold, qnew)
+        return (relaxation_functional(tmp1, tmp_partitioned, semi) - energy_old)
+    end
+    # close it over the parameters for less allocations
+    root_closure(g) = root(g, tmp1, tmp_partitioned, qold, qnew, energy_old)
 
-        convex_combination!(tmp2, gamma_hi, qold, qnew)
-        val2 = relaxation_functional(tmp1, tmp2, semi) - energy_old
+    @trixi_timeit timer() "relaxation" begin
+        convex_combination!(tmp_partitioned, gamma_lo, qold, qnew)
+        val1 = relaxation_functional(tmp1, tmp_partitioned, semi) - energy_old
+
+        convex_combination!(tmp_partitioned, gamma_hi, qold, qnew)
+        val2 = relaxation_functional(tmp1, tmp_partitioned, semi) - energy_old
 
         if (val1 * val2) > 0
             terminate_integration = true
         else
-            gamma = find_zero(root, (gamma_lo, gamma_hi), AlefeldPotraShi())
+            gamma = find_zero(root_closure, (gamma_lo, gamma_hi), AlefeldPotraShi())
         end
 
         if gamma < eps(typeof(gamma))
             terminate_integration = true
         end
 
-        convex_combination!(tmp2, gamma, qold, qnew)
-        DiffEqBase.set_u!(integrator, tmp2)
+        convex_combination!(qnew, gamma, qold, qnew)
+        DiffEqBase.set_u!(integrator, qnew)
 
         if !isapprox(tnew, first(integrator.opts.tstops))
-            tgamma = convex_combination(gamma, told, tnew) # scalar combination
+            tgamma = told + gamma * (tnew - told) # convex_combination scalar eq.
             DiffEqBase.set_t!(integrator, tgamma)
         end
 

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -58,8 +58,10 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             RealT = real(solver), uEltype = RealT,
                             # tmp1 is needed for the `RelaxationCallback`
                             initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                             tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
-                                 Val(nvariables(equations))))))
+                                            #tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
+                                            #tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh),
+                                            # Val(nvariables(equations)))
+                                ))
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -58,10 +58,10 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             RealT = real(solver), uEltype = RealT,
                             # tmp1 is needed for the `RelaxationCallback`
                             initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                            #tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
-                                            #tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh),
-                                            # Val(nvariables(equations)))
-                                ))
+                                             #tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
+                                             #tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh),
+                                             # Val(nvariables(equations)))
+                                             ))
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -47,9 +47,9 @@ end
                        RealT=real(solver),
                        uEltype=RealT,
                        initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                        tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
-                                                                                           nnodes(mesh)),
-                                                                                 Val(nvariables(equations))))))
+                                        tmp_partitioned = allocate_coefficients(mesh,
+                                                                                     equations,
+                                                                                     solver)))
 
 Construct a semidiscretization of a PDE.
 """
@@ -61,9 +61,9 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             RealT = real(solver), uEltype = RealT,
                             # tmp1 is needed for the `RelaxationCallback`
                             initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                             tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
-                                                                                                nnodes(mesh)),
-                                                                                     Val(nvariables(equations))))))
+                                             tmp_partitioned = allocate_coefficients(mesh,
+                                                                                     equations,
+                                                                                     solver)))
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -57,7 +57,7 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             # `RealT` is used as real type for node locations etc.
                             # while `uEltype` is used as element type of solutions etc.
                             RealT = real(solver), uEltype = RealT,
-                            # tmp1 is needed for the `RelaxationCallback`
+                            # `tmp1` and `tmp_partitioned` are needed for the `RelaxationCallback`
                             initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
                                              tmp_partitioned = allocate_coefficients(mesh,
                                                                                      equations,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -57,7 +57,9 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             # while `uEltype` is used as element type of solutions etc.
                             RealT = real(solver), uEltype = RealT,
                             # tmp1 is needed for the `RelaxationCallback`
-                            initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),))
+                            initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
+                                             tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
+                                 Val(nvariables(equations))))))
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -58,10 +58,11 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                             RealT = real(solver), uEltype = RealT,
                             # tmp1 is needed for the `RelaxationCallback`
                             initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                             #tmp222 = ArrayPartition(ntuple(_ -> zeros(real(solver), nnodes(mesh)),
-                                             #tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh),
-                                             # Val(nvariables(equations)))
-                                             ))
+                                             tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
+                                                                                                nnodes(mesh)),
+                                                                                     Val(nvariables(equations))))))
+    #  tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh))
+
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,
@@ -145,6 +146,7 @@ function integrate_quantity!(quantity, func, q, semi::Semidiscretization)
     for i in eachnode(semi)
         quantity[i] = func(get_node_vars(q, semi.equations, i), semi.equations)
     end
+    # @show "hey"
     integrate(quantity, semi)
 end
 

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -53,7 +53,6 @@ end
 
 Construct a semidiscretization of a PDE.
 """
-
 function Semidiscretization(mesh, equations, initial_condition, solver;
                             source_terms = nothing,
                             boundary_conditions = boundary_condition_periodic,

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -61,7 +61,6 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                                              tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
                                                                                                 nnodes(mesh)),
                                                                                      Val(nvariables(equations))))))
-    #  tmp222 = Array{RealT}(undef, nvariables(equations)*nnodes(mesh))
 
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
@@ -146,7 +145,6 @@ function integrate_quantity!(quantity, func, q, semi::Semidiscretization)
     for i in eachnode(semi)
         quantity[i] = func(get_node_vars(q, semi.equations, i), semi.equations)
     end
-    # @show "hey"
     integrate(quantity, semi)
 end
 

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -47,9 +47,7 @@ end
                        RealT=real(solver),
                        uEltype=RealT,
                        initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
-                                        tmp_partitioned = allocate_coefficients(mesh,
-                                                                                     equations,
-                                                                                     solver)))
+                                        tmp_partitioned = allocate_coefficients(mesh, equations, solver)))
 
 Construct a semidiscretization of a PDE.
 """

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -46,10 +46,14 @@ end
                        boundary_conditions=boundary_condition_periodic,
                        RealT=real(solver),
                        uEltype=RealT,
-                       initial_cache=(tmp1 = Array{RealT}(undef, nnodes(mesh)),))
+                       initial_cache = (tmp1 = Array{RealT}(undef, nnodes(mesh)),
+                                        tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
+                                                                                           nnodes(mesh)),
+                                                                                 Val(nvariables(equations))))))
 
 Construct a semidiscretization of a PDE.
 """
+
 function Semidiscretization(mesh, equations, initial_condition, solver;
                             source_terms = nothing,
                             boundary_conditions = boundary_condition_periodic,
@@ -61,7 +65,6 @@ function Semidiscretization(mesh, equations, initial_condition, solver;
                                              tmp_partitioned = ArrayPartition(ntuple(_ -> zeros(real(solver),
                                                                                                 nnodes(mesh)),
                                                                                      Val(nvariables(equations))))))
-
     cache = (;
              create_cache(mesh, equations, solver, initial_condition, boundary_conditions,
                           RealT, uEltype)...,


### PR DESCRIPTION
Trying to close https://github.com/NumericalMathematics/DispersiveShallowWater.jl/issues/11

This is roughly a 6x improvements on allocations for the relaxation for `bbm_bbm_1d_upwind_relaxation.jl` (I didnt benchmark the others locally)

It is still doing allocations because of ``tmp2 = similar(qold)``.
I would love to also unpack a tmp222 (with different name if merged) from the cache. It is possible to create a fitting cache in initial_cache (see commented out changes to src/semidiscretization.jl), but it is not working. I think there is some black magic going on in ``integrate_quantity!`` i couldn't figure out yet.

PS: the files changed look really messy. If you open the old and new file next to each other it should be way more clear what is happening.


`bbm_bbm_1d_upwind_relaxation.jl`, from:
```julia
───────────────────────────────────────────────────────────────────────────────────────────
              DispersiveSWE                       Time                    Allocations      
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 2.53s /  65.4%            619MiB /  88.9%

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
analyze solution                    268    769ms   46.4%  2.87ms   13.2MiB    2.4%  50.2KiB
rhs!                              18.7k    720ms   43.5%  38.4μs    150MiB   27.2%  8.19KiB
  solving elliptic system deta    18.7k    345ms   20.9%  18.4μs   74.9MiB   13.6%  4.09KiB
  solving elliptic system dv      18.7k    335ms   20.2%  17.9μs   74.9MiB   13.6%  4.09KiB
  ~rhs!~                          18.7k   23.5ms    1.4%  1.25μs   1.84KiB    0.0%    0.10B
  deta hyperbolic                 37.5k   9.29ms    0.6%   248ns     0.00B    0.0%    0.00B
  dv hyperbolic                   37.5k   6.81ms    0.4%   182ns     0.00B    0.0%    0.00B
  source terms                    18.7k    490μs    0.0%  26.2ns     0.00B    0.0%    0.00B
relaxation                        2.68k    167ms   10.1%  62.3μs    387MiB   70.4%   148KiB
───────────────────────────────────────────────────────────────────────────────────────────
```

to (edited for newest version)

```julia
───────────────────────────────────────────────────────────────────────────────────────────
              DispersiveSWE                       Time                    Allocations
                                         ───────────────────────   ────────────────────────
            Tot / % measured:                 1.63s /  95.9%            166MiB /  98.9%

Section                          ncalls     time    %tot     avg     alloc    %tot      avg
───────────────────────────────────────────────────────────────────────────────────────────
analyze solution                    268    864ms   55.5%  3.23ms   13.1MiB    8.0%  50.2KiB
rhs!                              18.7k    647ms   41.5%  34.5μs    150MiB   91.2%  8.19KiB
  solving elliptic system deta    18.7k    310ms   19.9%  16.6μs   74.9MiB   45.6%  4.09KiB
  solving elliptic system dv      18.7k    300ms   19.2%  16.0μs   74.9MiB   45.6%  4.09KiB
  ~rhs!~                          18.7k   21.4ms    1.4%  1.14μs   1.84KiB    0.0%    0.10B
  deta hyperbolic                 37.5k   8.38ms    0.5%   223ns     0.00B    0.0%    0.00B
  dv hyperbolic                   37.5k   6.59ms    0.4%   176ns     0.00B    0.0%    0.00B
  source terms                    18.7k    460μs    0.0%  24.5ns     0.00B    0.0%    0.00B
relaxation                        2.68k   47.1ms    3.0%  17.6μs   1.35MiB    0.8%     529B
───────────────────────────────────────────────────────────────────────────────────────────
```