### PR TITLE
Rename source term variables consistently

### DIFF
--- a/src/equations/bbm_1d.jl
+++ b/src/equations/bbm_1d.jl
@@ -104,10 +104,10 @@ function source_terms_manufactured(q, x, t, equations::BBMEquation1D)
     a4 = sinpi(t - 2 * x)
     a5 = sinpi(2 * t - 4 * x)
     a6 = exp(t / 2)
-    dq1 = -pi^2 * D^2 * (a4 + 2 * pi * a3) * a6 / 3 - 3 * pi * a2 * exp(t) * a5 / 2 +
-          2 * pi * a1 * a6 * a3 - a6 * a4 / 2 - pi * a6 * a3
+    s1 = -pi^2 * D^2 * (a4 + 2 * pi * a3) * a6 / 3 - 3 * pi * a2 * exp(t) * a5 / 2 +
+         2 * pi * a1 * a6 * a3 - a6 * a4 / 2 - pi * a6 * a3
 
-    return SVector(dq1)
+    return SVector(s1)
 end
 
 function create_cache(mesh, equations::BBMEquation1D,

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -125,19 +125,19 @@ function source_terms_manufactured(q, x, t, equations::BBMBBMEquations1D)
     a10 = exp(t)
     a14 = exp(t / 2)
     a15 = exp(3 * t / 2)
-    dq1 = -2 * pi^2 * (4 * pi * a6 - a7) * (2 * a1 + 5)^2 * a10 / 3 +
-          8 * pi^2 * (a6 + 4 * pi * a7) * (2 * a1 + 5) * a10 * a2 / 3 +
-          2 * pi * (2 * a1 + 5) * a14 * a3 - 2 * pi * a15 * a4 * a6 +
-          2 * pi * a15 * a3 * a7 + 4 * pi * a14 * a2 * a4 -
-          4 * pi * a10 * a6 + a10 * a7
-    dq2 = 2 * pi * g * a10 * a6 -
-          pi^2 *
-          (8 * (2 * pi * a4 - a3) * (2 * a1 + 5) * a2 +
-           (a4 + 2 * pi * a3) * (2 * a1 + 5)^2 +
-           4 * (a4 + 2 * pi * a3) * (16 * a9^4 - 26 * a9^2 + 7)) * a14 /
-          3 - a14 * a4 / 2 - pi * a14 * a3 - pi * a10 * a5
+    s1 = -2 * pi^2 * (4 * pi * a6 - a7) * (2 * a1 + 5)^2 * a10 / 3 +
+         8 * pi^2 * (a6 + 4 * pi * a7) * (2 * a1 + 5) * a10 * a2 / 3 +
+         2 * pi * (2 * a1 + 5) * a14 * a3 - 2 * pi * a15 * a4 * a6 +
+         2 * pi * a15 * a3 * a7 + 4 * pi * a14 * a2 * a4 -
+         4 * pi * a10 * a6 + a10 * a7
+    s2 = 2 * pi * g * a10 * a6 -
+         pi^2 *
+         (8 * (2 * pi * a4 - a3) * (2 * a1 + 5) * a2 +
+          (a4 + 2 * pi * a3) * (2 * a1 + 5)^2 +
+          4 * (a4 + 2 * pi * a3) * (16 * a9^4 - 26 * a9^2 + 7)) * a14 /
+         3 - a14 * a4 / 2 - pi * a14 * a3 - pi * a10 * a5
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 function source_terms_manufactured(q, x, t, equations::BBMBBMEquations1D{BathymetryFlat})
@@ -151,13 +151,13 @@ function source_terms_manufactured(q, x, t, equations::BBMBBMEquations1D{Bathyme
     a10 = exp(t)
     a14 = exp(t / 2)
     a15 = exp(3 * t / 2)
-    dq1 = -2 * pi^2 * D^2 * (4 * pi * a6 - a7) * a10 / 3 + 2 * pi * D * a14 * a3 -
-          2 * pi * a15 * a4 * a6 + 2 * pi * a15 * a3 * a7 -
-          4 * pi * a10 * a6 + a10 * a7
-    dq2 = -pi^2 * D^2 * (a4 + 2 * pi * a3) * a14 / 3 + 2 * pi * g * a10 * a6 -
-          a14 * a4 / 2 - pi * a14 * a3 - pi * a10 * a5
+    s1 = -2 * pi^2 * D^2 * (4 * pi * a6 - a7) * a10 / 3 + 2 * pi * D * a14 * a3 -
+         2 * pi * a15 * a4 * a6 + 2 * pi * a15 * a3 * a7 -
+         4 * pi * a10 * a6 + a10 * a7
+    s2 = -pi^2 * D^2 * (a4 + 2 * pi * a3) * a14 / 3 + 2 * pi * g * a10 * a6 -
+         a14 * a4 / 2 - pi * a14 * a3 - pi * a10 * a5
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 """
@@ -195,14 +195,14 @@ function source_terms_manufactured_reflecting(q, x, t, equations::BBMBBMEquation
     a11 = exp(2 * t)
     a12 = cospi(3 * x)
     a13 = sinpi(3 * x)
-    dq1 = (pi * x * a11 * a1 + 4 * pi * x * a8 + 3 * pi * x * a12 +
+    s1 = (pi * x * a11 * a1 + 4 * pi * x * a8 + 3 * pi * x * a12 +
            20 * pi^2 * (1 - a1)^2 * a10 * a8 / 3 + a11 * a2 / 2 + 2 * a10 * a8 +
            7 * pi^2 * a10 * a8 / 3 + 14 * pi^2 * a10 * a12 + 4 * a9 + a13) * a10
-    dq2 = (-pi * g * a10 * a9 + pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9 +
+    s2 = (-pi * g * a10 * a9 + pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9 +
            pi * (400 * pi * x * a9^5 - 824 * pi * x * a9^3 + 385 * pi * x * a9 -
             160 * a9^4 * a8 + 336 * a9^2 * a8 - 98 * a8) / 6) * a10
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 function source_terms_manufactured_reflecting(q, x, t,
@@ -215,12 +215,12 @@ function source_terms_manufactured_reflecting(q, x, t,
     a9 = sinpi(x)
     a10 = exp(t)
     a11 = exp(2 * t)
-    dq1 = (pi^2 * D^2 * a10 * a8 / 3 + pi * D * x * a8 + D * a9 + pi * x * a11 * a1 +
+    s1 = (pi^2 * D^2 * a10 * a8 / 3 + pi * D * x * a8 + D * a9 + pi * x * a11 * a1 +
            a11 * a2 / 2 + 2 * a10 * a8) * a10
-    dq2 = (pi * D^2 * (pi * x * a9 - 2 * a8) / 6 - pi * g * a10 * a9 +
+    s2 = (pi * D^2 * (pi * x * a9 - 2 * a8) / 6 - pi * g * a10 * a9 +
            pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9) * a10
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 """

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -196,11 +196,11 @@ function source_terms_manufactured_reflecting(q, x, t, equations::BBMBBMEquation
     a12 = cospi(3 * x)
     a13 = sinpi(3 * x)
     s1 = (pi * x * a11 * a1 + 4 * pi * x * a8 + 3 * pi * x * a12 +
-           20 * pi^2 * (1 - a1)^2 * a10 * a8 / 3 + a11 * a2 / 2 + 2 * a10 * a8 +
-           7 * pi^2 * a10 * a8 / 3 + 14 * pi^2 * a10 * a12 + 4 * a9 + a13) * a10
+          20 * pi^2 * (1 - a1)^2 * a10 * a8 / 3 + a11 * a2 / 2 + 2 * a10 * a8 +
+          7 * pi^2 * a10 * a8 / 3 + 14 * pi^2 * a10 * a12 + 4 * a9 + a13) * a10
     s2 = (-pi * g * a10 * a9 + pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9 +
-           pi * (400 * pi * x * a9^5 - 824 * pi * x * a9^3 + 385 * pi * x * a9 -
-            160 * a9^4 * a8 + 336 * a9^2 * a8 - 98 * a8) / 6) * a10
+          pi * (400 * pi * x * a9^5 - 824 * pi * x * a9^3 + 385 * pi * x * a9 -
+           160 * a9^4 * a8 + 336 * a9^2 * a8 - 98 * a8) / 6) * a10
 
     return SVector(s1, s2, zero(s1))
 end
@@ -216,9 +216,9 @@ function source_terms_manufactured_reflecting(q, x, t,
     a10 = exp(t)
     a11 = exp(2 * t)
     s1 = (pi^2 * D^2 * a10 * a8 / 3 + pi * D * x * a8 + D * a9 + pi * x * a11 * a1 +
-           a11 * a2 / 2 + 2 * a10 * a8) * a10
+          a11 * a2 / 2 + 2 * a10 * a8) * a10
     s2 = (pi * D^2 * (pi * x * a9 - 2 * a8) / 6 - pi * g * a10 * a9 +
-           pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9) * a10
+          pi * x^2 * a10 * a2 / 2 + x * a10 * a9^2 + x * a9) * a10
 
     return SVector(s1, s2, zero(s1))
 end

--- a/src/equations/hyperbolic_serre_green_naghdi_1d.jl
+++ b/src/equations/hyperbolic_serre_green_naghdi_1d.jl
@@ -222,28 +222,24 @@ function source_terms_manufactured(q, x, t,
 
     a1 = sinpi(4 * t - 2 * x)
     a2 = cospi(4 * t - 2 * x)
-    a3 = sinpi(2 * t - x)
-    a4 = cospi(2 * t - x)
     a5 = sinpi(t - 2 * x)
     a6 = cospi(t - 2 * x)
     a7 = sinpi(2 * x)
     a8 = cospi(2 * x)
-    a9 = sinpi(2 * t - 4 * x)
-    e1 = exp(t)
-    e2 = exp(t / 2)
+    a9 = (-a2 - 2 * a8 - 7)
+    a10 = (2 * pi * a1 - 4 * pi * a7)
 
     # Source terms for variable bathymetry
-    dh = -4 * pi * a1 - a5 * (2 * pi * a1 - 4 * pi * a7) + 2 * pi * a6 * (a2 + 2 * a8 + 7)
-    dv = -2 * pi * a5 * a6 - pi * a6 + 4 * pi * a7 * g + g * (2 * pi * a1 - 4 * pi * a7)
-    dD = zero(dh)
-    dw = 8 * pi^2 * a1 * a6 -
-         a5 *
-         (4 * pi^2 * a5 * (-a2 - 2 * a8 - 7) + 2 * pi * a6 * (-2 * pi * a1 + 4 * pi * a7)) -
-         2 * pi^2 * a5 * (-a2 - 2 * a8 - 7)
-    dH = -4 * pi * a1 - 6 * pi * a5 * a7 - a5 * (2 * pi * a1 - 4 * pi * a7) -
-         2 * pi * a6 * (-a2 - 2 * a8 - 7)
+    s1 = -4 * pi * a1 - a5 * a10 - 2 * pi * a6 * a9
+    s2 = -2 * pi * a5 * a6 - pi * a6 + 4 * pi * a7 * g + g * a10
+    s3 = zero(s1)
+    s4 = 8 * pi^2 * a1 * a6 -
+         a5 * (4 * pi^2 * a5 * a9 - 2 * pi * a6 * a10) -
+         2 * pi^2 * a5 * a9
+    s5 = -4 * pi * a1 - 6 * pi * a5 * a7 - a5 * a10 -
+         2 * pi * a6 * a9
 
-    return SVector(dh, dv, dD, dw, dH)
+    return SVector(s1, s2, s3, s4, s5)
 end
 
 function create_cache(mesh, equations::HyperbolicSerreGreenNaghdiEquations1D,
@@ -254,7 +250,7 @@ function create_cache(mesh, equations::HyperbolicSerreGreenNaghdiEquations1D,
     # via ForwardDiff.jl. We also pass the second argument determining the chunk size since the
     # typical use case is to compute Jacobians of the full `rhs!` evaluation, where the complete
     # state vector is `q`, which is bigger than the storage for a single scalar variable.
-    # nvariables(equations) = 5: eta, v, D, w, H 
+    # nvariables(equations) = 5: eta, v, D, w, H
     N = ForwardDiff.pickchunksize(nvariables(equations) * nnodes(mesh))
     template = ones(RealT, nnodes(mesh))
     h = DiffCache(template, N)

--- a/src/equations/kdv_1d.jl
+++ b/src/equations/kdv_1d.jl
@@ -100,9 +100,9 @@ function source_terms_manufactured(q, x, t, equations::KdVEquation1D)
     c1 = sqrt(g / D)
 
     s1 = -0.5 * a1 * b1 - pi * a2 * b1 +
-          2pi * a2 * c0 * b1 +
-          3pi * a2 * c1 * (1 + a1 * b1) * b1 -
-          (4 / 3) * D^2 * pi^3 * a2 * c0 * b1
+         2pi * a2 * c0 * b1 +
+         3pi * a2 * c1 * (1 + a1 * b1) * b1 -
+         (4 / 3) * D^2 * pi^3 * a2 * c0 * b1
 
     return SVector(s1)
 end

--- a/src/equations/kdv_1d.jl
+++ b/src/equations/kdv_1d.jl
@@ -99,12 +99,12 @@ function source_terms_manufactured(q, x, t, equations::KdVEquation1D)
     c0 = sqrt(g * D)
     c1 = sqrt(g / D)
 
-    dq1 = -0.5 * a1 * b1 - pi * a2 * b1 +
+    s1 = -0.5 * a1 * b1 - pi * a2 * b1 +
           2pi * a2 * c0 * b1 +
           3pi * a2 * c1 * (1 + a1 * b1) * b1 -
           (4 / 3) * D^2 * pi^3 * a2 * c0 * b1
 
-    return SVector(dq1)
+    return SVector(s1)
 end
 
 function create_cache(mesh, equations::KdVEquation1D,
@@ -118,7 +118,7 @@ function create_cache(mesh, equations::KdVEquation1D,
     c_1 = 0.5 * sqrt(g / D)
 
     # We use `DiffCache` from PreallocationTools.jl to enable automatic/algorithmic differentiation
-    # via ForwardDiff.jl. 
+    # via ForwardDiff.jl.
     # nvariables(equations) = 1: eta
     N = ForwardDiff.pickchunksize(nvariables(equations) * nnodes(mesh))
     template = ones(RealT, nnodes(mesh))
@@ -159,7 +159,7 @@ function rhs!(dq, q, t, mesh, equations::KdVEquation1D, initial_condition,
             D1 = solver.D1
         end
 
-        # deta = 1 / 6 sqrt(g * D) D^2 eta_xxx 
+        # deta = 1 / 6 sqrt(g * D) D^2 eta_xxx
         @.. deta = -1 / 6 * c_0 * DD * tmp_1
     end
 
@@ -172,7 +172,7 @@ function rhs!(dq, q, t, mesh, equations::KdVEquation1D, initial_condition,
         # eta_x = D1 * eta
         mul!(tmp_1, D1, eta)
 
-        # deta -= sqrt(g * D) * eta_x + 1 / 2 * sqrt(g / D) * (eta * eta_x + eta2_x) 
+        # deta -= sqrt(g * D) * eta_x + 1 / 2 * sqrt(g / D) * (eta * eta_x + eta2_x)
         @.. deta -= (c_0 * tmp_1 + c_1 * (eta * tmp_1 + tmp_2))
     end
 

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -233,10 +233,10 @@ function source_terms_manufactured(q, x, t,
     a7 = cospi(4t - 2x)
     a8 = 5 + a7
     a9 = a6 * a7
-    a10 = a9 * a7
+    a10 = a6 * a7^2
     a11 = 1 - a4
     a12 = a2 * a4
-    a13 = a12 * a4
+    a13 = a2 * a4^2
 
     s1 = 2π * (a6 * a11 + a3 * a8 - 2 * a6)
 

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -130,7 +130,7 @@ function initial_condition_manufactured(x, t,
 
     return SVector(eta, v, D)
 end
-#= 
+#=
 The source terms where calculated using a CAS, here Symbolics.jl
 See code: https://github.com/NumericalMathematics/DispersiveShallowWater.jl/pull/180#discussion_r2068562090
 For a chosen h and v, in this case
@@ -158,25 +158,25 @@ function source_terms_manufactured(q, x, t,
     a5 = sinpi(2t - 4x)
     a6 = sinpi(4t - 2x)
     a7 = 5 + cospi(4t - 2x)
+    a8 = a3 * a7^3
     a9 = 1 - a4
+    a10 = 8π^3 * a6 * a7^2
 
-    dq1 = 2π * (-a6 - a6 * a4 + a3 * a7)
+    s1 = 2π * (-a6 - a6 * a4 + a3 * a7)
 
-    dq2 = (-π * a3 * a7
-           + 2g * π * a6 * a7
-           + 2π * a3 * a7 * a9
-           -
-           (1 / 3) * (-12π^3 * a6 * a4 * a7^2
-                      +
-                      4π^3 * a3 * a7^3)
-           + (4 / 3) * π^3 * a5 * a7^3
-           + 8π^3 * a6 * a3^2 * a7^2
-           -
-           8π^3 * a6 * a7^2 * a9 * a4
-           +
-           (8 / 3) * π^3 * a3 * a7^3 * a9)
+    s2 = (-π * a3 * a7
+          + 2g * π * a6 * a7
+          + 2π * a3 * a7 * a9
+          -
+          (1 / 3) * (-12π^3 * a6 * a4 * a7^2
+                     +
+                     4π^3 * a8)
+          + (4 / 3) * π^3 * a5 * a7^3
+          + a10 * a3^2 - a10 * a9 * a4
+          +
+          (8 / 3) * π^3 * a8 * a9)
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 function source_terms_manufactured(q, x, t,
@@ -194,9 +194,9 @@ function source_terms_manufactured(q, x, t,
     a8 = 5 + a7
     a11 = 1 - a4
 
-    dh = 2π * (a6 * a11 + a3 * a8 - 2 * a6)
+    s1 = 2π * (a6 * a11 + a3 * a8 - 2 * a6)
 
-    dv = π *
+    s2 = π *
          (2 * g * a2 * a7 + 10 * g * a2 + 2 * g * a6 * a7 + 10 * g * a6 + a3 * a7 + 5 * a3 -
           2 * a3 * a4 * a7 - 10 * a3 * a4) +
          π^3 * (8 * a1 * a2 * a4^2 * a7 + 40 * a1 * a2 * a4^2 - 16 * a1 * a2 * a4 * a7 -
@@ -217,7 +217,7 @@ function source_terms_manufactured(q, x, t,
           4 * a4 * a6 * a7^2 - 40 * a4 * a6 * a7 - 100 * a4 * a6 + 4 * a5 * a7^3 / 3 +
           20 * a5 * a7^2 + 100 * a5 * a7 + 500 * a5 / 3)
 
-    return SVector(dh, dv, zero(dh))
+    return SVector(s1, s2, zero(s1))
 end
 
 function source_terms_manufactured(q, x, t,
@@ -232,31 +232,35 @@ function source_terms_manufactured(q, x, t,
     a6 = sinpi(4t - 2x)
     a7 = cospi(4t - 2x)
     a8 = 5 + a7
+    a9 = a6 * a7
+    a10 = a9 * a7
     a11 = 1 - a4
+    a12 = a2 * a4
+    a13 = a12 * a4
 
-    dh = 2π * (a6 * a11 + a3 * a8 - 2 * a6)
+    s1 = 2π * (a6 * a11 + a3 * a8 - 2 * a6)
 
-    dv = π * (2 * a2 * a7 * g + 10 * a2 * g - 2 * a3 * a4 * a7 - 10 * a3 * a4 + a3 * a7 +
-          5 * a3 + 2 * a6 * a7 * g + 10 * a6 * g) +
-         π^3 * (6 * a1 * a2 * a4^2 * a7 + 30 * a1 * a2 * a4^2 - 12 * a1 * a2 * a4 * a7 -
-          60 * a1 * a2 * a4 + 6 * a1 * a2 * a7 + 30 * a1 * a2 - 12 * a1 * a3 * a4 * a7^2 -
+    s2 = π * (2 * a2 * a7 * g + 10 * a2 * g - 2 * a3 * a4 * a7 - 10 * a3 * a4 + a3 * a7 +
+          5 * a3 + 2 * a9 * g + 10 * a6 * g) +
+         π^3 * (6 * a1 * a13 * a7 + 30 * a1 * a13 - 12 * a1 * a12 * a7 -
+          60 * a1 * a12 + 6 * a1 * a2 * a7 + 30 * a1 * a2 - 12 * a1 * a3 * a4 * a7^2 -
           120 * a1 * a3 * a4 * a7 - 300 * a1 * a3 * a4 + 10 * a1 * a3 * a7^2 +
-          100 * a1 * a3 * a7 + 250 * a1 * a3 + 8 * a1 * a4^2 * a6 * a7 +
-          40 * a1 * a4^2 * a6 - 16 * a1 * a4 * a6 * a7 - 80 * a1 * a4 * a6 +
-          8 * a1 * a6 * a7 + 40 * a1 * a6 - 6 * a2^2 * a3 * a4 * a7 - 30 * a2^2 * a3 * a4 +
+          100 * a1 * a3 * a7 + 250 * a1 * a3 + 8 * a1 * a4^2 * a9 +
+          40 * a1 * a4^2 * a6 - 16 * a1 * a4 * a9 - 80 * a1 * a4 * a6 +
+          8 * a1 * a9 + 40 * a1 * a6 - 6 * a2^2 * a3 * a4 * a7 - 30 * a2^2 * a3 * a4 +
           3 * a2^2 * a3 * a7 + 15 * a2^2 * a3 + 8 * a2 * a3^2 * a7^2 + 80 * a2 * a3^2 * a7 +
-          200 * a2 * a3^2 - 8 * a2 * a3 * a4 * a6 * a7 - 40 * a2 * a3 * a4 * a6 +
-          4 * a2 * a3 * a6 * a7 + 20 * a2 * a3 * a6 - 4 * a2 * a4^2 * a7^2 -
-          40 * a2 * a4^2 * a7 - 100 * a2 * a4^2 + 8 * a2 * a4 * a7^2 + 80 * a2 * a4 * a7 +
-          200 * a2 * a4 - 4 * a2 * a7^2 - 40 * a2 * a7 - 100 * a2 + 8 * a3^2 * a6 * a7^2 +
-          80 * a3^2 * a6 * a7 + 200 * a3^2 * a6 - 8 * a3 * a4 * a7^3 / 3 -
+          200 * a2 * a3^2 - 8 * a2 * a3 * a4 * a9 - 40 * a2 * a3 * a4 * a6 +
+          4 * a2 * a3 * a9 + 20 * a2 * a3 * a6 - 4 * a13 * a7^2 -
+          40 * a13 * a7 - 100 * a13 + 8 * a12 * a7^2 + 80 * a12 * a7 +
+          200 * a12 - 4 * a2 * a7^2 - 40 * a2 * a7 - 100 * a2 + 8 * a3^2 * a10 +
+          80 * a3^2 * a9 + 200 * a3^2 * a6 - 8 * a3 * a4 * a7^3 / 3 -
           40 * a3 * a4 * a7^2 - 200 * a3 * a4 * a7 - 1000 * a3 * a4 / 3 +
           4 * a3 * a7^3 / 3 + 20 * a3 * a7^2 + 100 * a3 * a7 + 500 * a3 / 3 +
-          8 * a4^2 * a6 * a7^2 + 80 * a4^2 * a6 * a7 + 200 * a4^2 * a6 -
-          4 * a4 * a6 * a7^2 - 40 * a4 * a6 * a7 - 100 * a4 * a6 + 4 * a5 * a7^3 / 3 +
+          8 * a4^2 * a10 + 80 * a4^2 * a6 * a7 + 200 * a4^2 * a6 -
+          4 * a4 * a10 - 40 * a4 * a6 * a7 - 100 * a4 * a6 + 4 * a5 * a7^3 / 3 +
           20 * a5 * a7^2 + 100 * a5 * a7 + 500 * a5 / 3)
 
-    return SVector(dh, dv, zero(dh))
+    return SVector(s1, s2, zero(s1))
 end
 
 # flat bathymetry

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -122,12 +122,14 @@ function source_terms_manufactured(q, x, t, equations::SvaerdKalischEquations1D)
             3.2 * pi^2 * alpha * a12 * a13 * a1^2 / a11 + 0.56 * pi^2 * alpha * a12 * a1^2) *
            a9 * a7 / (a14) -
            10.0 * pi * a15 * a16^2 * a9 * a7 / (alpha^2 * g * a13^4 * a11))
+    a22 = 2 * pi^2 * a8
+    a23 = a15 * a17
 
-    dq1 = -5.0 * a21 + a20 + 4 * pi * a9 * a7 + a10 - 5.0 * a15 * a17 * a16 / (a14)
+    s1 = -5.0 * a21 + a20 + 4 * pi * a9 * a7 + a10 - 5.0 * a23 * a16 / (a14)
 
-    dq2 = -25.0 * beta * (-2 * pi^2 * a8 * a3 + 4 * pi^3 * a8 * a4) * a13^2 * a11 +
-          100.0 * pi * beta * (2 * pi^2 * a8 * a3 + pi * a8 * a4) * a13^2 * a1 +
-          40.0 * pi * beta * (2 * pi^2 * a8 * a3 + pi * a8 * a4) * a13 * a11 * a1 -
+    s2 = -25.0 * beta * (-a22 * a3 + 4 * pi^3 * a8 * a4) * a13^2 * a11 +
+          100.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13^2 * a1 +
+          40.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13 * a11 * a1 -
           2 * pi * g * a19 * a9 * a7 + 100.0 * pi^3 * gamma * a12 * a13^2 * a11 * a8 * a4 -
           300.0 * pi^3 * gamma * a12 * a13^2 * a8 * a1 * a3 -
           80.0 * pi^3 * gamma * a12 * a13 * a11 * a8 * a1 * a3 -
@@ -136,12 +138,12 @@ function source_terms_manufactured(q, x, t, equations::SvaerdKalischEquations1D)
            50.0 * (4.0 * a2 / a11 + 0.16 * a1^2 / a13^2) * a13^2 * a11 * a6 -
            200.0 * a13^2 * a11 * a6 - 1200.0 * a13^2 * a1 * a5 - 400.0 * a13^2 * a2 * a6 +
            800.0 * a13^2 * a1^2 * a6 / a11 - 320.0 * a13 * a11 * a1 * a5 +
-           960.0 * a13 * a1^2 * a6) * a8 / 2 - 10.0 * pi * a15 * a17 * a8 * a4 -
-          2.5 * a21 * a8 * a3 + (5.0 * a21 + 5.0 * a15 * a17 * a16 / (a14)) * a8 * a3 / 2 +
+           960.0 * a13 * a1^2 * a6) * a8 / 2 - 10.0 * pi * a23 * a8 * a4 -
+          2.5 * a21 * a8 * a3 + (5.0 * a21 + 5.0 * a23 * a16 / (a14)) * a8 * a3 / 2 +
           (a8 * a3 / 2 - pi * a8 * a4) * a19 + a18 * a9 * a3^2 / 2 - (a20) * a8 * a3 / 2 +
-          3 * pi * a19 * a9 * a3 * a4 - 2.5 * a15 * a17 * a16 * a8 * a3 / (a14)
+          3 * pi * a19 * a9 * a3 * a4 - 2.5 * a23 * a16 * a8 * a3 / (a14)
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 """
@@ -185,14 +187,14 @@ function source_terms_manufactured_reflecting(q, x, t, equations::SvaerdKalischE
     a29 = -pi * a24 * a22 - 4.0 * pi * a1
     a30 = a26 * a24
     a31 = a26 * a27
-    dq1 = x * a29 * a27 + pi * x * a26 * a9 * a23 + a31 + 2 * a25
-    dq2 = 100.0 * pi * beta * a28 * a13^2 * a1 + 40.0 * pi * beta * a28 * a13 * a11 * a1 -
+    s1 = x * a29 * a27 + pi * x * a26 * a9 * a23 + a31 + 2 * a25
+    s2 = 100.0 * pi * beta * a28 * a13^2 * a1 + 40.0 * pi * beta * a28 * a13 * a11 * a1 -
           25.0 * beta * (-pi^2 * x * a27 + 2 * pi * a9 * a23) * a13^2 * a11 -
           pi * g * a30 * a22 + x^2 * a29 * a24 * a22^2 / 2 + pi * x^2 * a30 * a22 * a23 +
           x * a28 * a31 / 2 + x * a30 * a22^2 + x * a31 -
           x * (x * a29 * a27 + pi * x * a26 * a9 * a23 + a31) * a27 / 2
 
-    return SVector(dq1, dq2, zero(dq1))
+    return SVector(s1, s2, zero(s1))
 end
 
 # For periodic boundary conditions

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -128,20 +128,20 @@ function source_terms_manufactured(q, x, t, equations::SvaerdKalischEquations1D)
     s1 = -5.0 * a21 + a20 + 4 * pi * a9 * a7 + a10 - 5.0 * a23 * a16 / (a14)
 
     s2 = -25.0 * beta * (-a22 * a3 + 4 * pi^3 * a8 * a4) * a13^2 * a11 +
-          100.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13^2 * a1 +
-          40.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13 * a11 * a1 -
-          2 * pi * g * a19 * a9 * a7 + 100.0 * pi^3 * gamma * a12 * a13^2 * a11 * a8 * a4 -
-          300.0 * pi^3 * gamma * a12 * a13^2 * a8 * a1 * a3 -
-          80.0 * pi^3 * gamma * a12 * a13 * a11 * a8 * a1 * a3 -
-          pi^3 * gamma * a12 *
-          (-50.0 * (3.2 * a13 * a2 - 1.28 * a1^2) * a11 * a6 -
-           50.0 * (4.0 * a2 / a11 + 0.16 * a1^2 / a13^2) * a13^2 * a11 * a6 -
-           200.0 * a13^2 * a11 * a6 - 1200.0 * a13^2 * a1 * a5 - 400.0 * a13^2 * a2 * a6 +
-           800.0 * a13^2 * a1^2 * a6 / a11 - 320.0 * a13 * a11 * a1 * a5 +
-           960.0 * a13 * a1^2 * a6) * a8 / 2 - 10.0 * pi * a23 * a8 * a4 -
-          2.5 * a21 * a8 * a3 + (5.0 * a21 + 5.0 * a23 * a16 / (a14)) * a8 * a3 / 2 +
-          (a8 * a3 / 2 - pi * a8 * a4) * a19 + a18 * a9 * a3^2 / 2 - (a20) * a8 * a3 / 2 +
-          3 * pi * a19 * a9 * a3 * a4 - 2.5 * a23 * a16 * a8 * a3 / (a14)
+         100.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13^2 * a1 +
+         40.0 * pi * beta * (a22 * a3 + pi * a8 * a4) * a13 * a11 * a1 -
+         2 * pi * g * a19 * a9 * a7 + 100.0 * pi^3 * gamma * a12 * a13^2 * a11 * a8 * a4 -
+         300.0 * pi^3 * gamma * a12 * a13^2 * a8 * a1 * a3 -
+         80.0 * pi^3 * gamma * a12 * a13 * a11 * a8 * a1 * a3 -
+         pi^3 * gamma * a12 *
+         (-50.0 * (3.2 * a13 * a2 - 1.28 * a1^2) * a11 * a6 -
+          50.0 * (4.0 * a2 / a11 + 0.16 * a1^2 / a13^2) * a13^2 * a11 * a6 -
+          200.0 * a13^2 * a11 * a6 - 1200.0 * a13^2 * a1 * a5 - 400.0 * a13^2 * a2 * a6 +
+          800.0 * a13^2 * a1^2 * a6 / a11 - 320.0 * a13 * a11 * a1 * a5 +
+          960.0 * a13 * a1^2 * a6) * a8 / 2 - 10.0 * pi * a23 * a8 * a4 -
+         2.5 * a21 * a8 * a3 + (5.0 * a21 + 5.0 * a23 * a16 / (a14)) * a8 * a3 / 2 +
+         (a8 * a3 / 2 - pi * a8 * a4) * a19 + a18 * a9 * a3^2 / 2 - (a20) * a8 * a3 / 2 +
+         3 * pi * a19 * a9 * a3 * a4 - 2.5 * a23 * a16 * a8 * a3 / (a14)
 
     return SVector(s1, s2, zero(s1))
 end
@@ -189,10 +189,10 @@ function source_terms_manufactured_reflecting(q, x, t, equations::SvaerdKalischE
     a31 = a26 * a27
     s1 = x * a29 * a27 + pi * x * a26 * a9 * a23 + a31 + 2 * a25
     s2 = 100.0 * pi * beta * a28 * a13^2 * a1 + 40.0 * pi * beta * a28 * a13 * a11 * a1 -
-          25.0 * beta * (-pi^2 * x * a27 + 2 * pi * a9 * a23) * a13^2 * a11 -
-          pi * g * a30 * a22 + x^2 * a29 * a24 * a22^2 / 2 + pi * x^2 * a30 * a22 * a23 +
-          x * a28 * a31 / 2 + x * a30 * a22^2 + x * a31 -
-          x * (x * a29 * a27 + pi * x * a26 * a9 * a23 + a31) * a27 / 2
+         25.0 * beta * (-pi^2 * x * a27 + 2 * pi * a9 * a23) * a13^2 * a11 -
+         pi * g * a30 * a22 + x^2 * a29 * a24 * a22^2 / 2 + pi * x^2 * a30 * a22 * a23 +
+         x * a28 * a31 / 2 + x * a30 * a22^2 + x * a31 -
+         x * (x * a29 * a27 + pi * x * a26 * a9 * a23 + a31) * a27 / 2
 
     return SVector(s1, s2, zero(s1))
 end


### PR DESCRIPTION
I renamed all source terms as `s1`, `s2`, ... for consistency and the `d` at the beginning of the variable names before indicated it's the time derivative `q1` , `h`, ..., but it's only one part of it (for equations involving elliptic systems it's also the source term before applying the elliptic operator). So I think it was a bit confusing. See also https://github.com/NumericalMathematics/DispersiveShallowWater.jl/pull/198.
On the way I also replaced some more expressions to avoid redundant computations and make the code a bit shorter.