### PR TITLE
Use `initial_condition_soliton` in more cases

### DIFF
--- a/src/equations/kdv_1d.jl
+++ b/src/equations/kdv_1d.jl
@@ -56,9 +56,10 @@ end
 """
     initial_condition_convergence_test(x, t, equations::KdVEquation1D, mesh)
 
-A traveling-wave solution used for convergence tests in a periodic domain, here for dimensional variables.
+A classical soliton solution of the KdV equation in dimensional variables. This can be used
+for convergence tests in a periodic domain, see [`initial_condition_convergence_test`](@ref).
 """
-function initial_condition_convergence_test(x, t, equations::KdVEquation1D, mesh)
+function initial_condition_soliton(x, t, equations::KdVEquation1D, mesh)
     g = gravity(equations)
     D = equations.D
     c0 = sqrt(g * D)
@@ -68,6 +69,17 @@ function initial_condition_convergence_test(x, t, equations::KdVEquation1D, mesh
     x_t = mod(x - c * t - xmin(mesh), xmax(mesh) - xmin(mesh)) + xmin(mesh)
     eta = A * sech(K * x_t)^2
     return SVector(eta)
+end
+
+"""
+    initial_condition_convergence_test(x, t, equations::KdVEquation1D, mesh)
+
+A soliton solution used for convergence tests in a periodic domain. Same as
+[`initial_condition_soliton`](@ref) for the [`KdVEquation1D`](@ref).
+"""
+function initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D,
+                                            mesh)
+    return initial_condition_soliton(x, t, equations, mesh)
 end
 
 """

--- a/src/equations/kdv_1d.jl
+++ b/src/equations/kdv_1d.jl
@@ -54,7 +54,7 @@ function KdVEquation1D(; gravity, D = 1.0, eta0 = 0.0)
 end
 
 """
-    initial_condition_convergence_test(x, t, equations::KdVEquation1D, mesh)
+    initial_condition_soliton(x, t, equations::KdVEquation1D, mesh)
 
 A classical soliton solution of the KdV equation in dimensional variables. This can be used
 for convergence tests in a periodic domain, see [`initial_condition_convergence_test`](@ref).
@@ -77,7 +77,7 @@ end
 A soliton solution used for convergence tests in a periodic domain. Same as
 [`initial_condition_soliton`](@ref) for the [`KdVEquation1D`](@ref).
 """
-function initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D,
+function initial_condition_convergence_test(x, t, equations::KdVEquation1D,
                                             mesh)
     return initial_condition_soliton(x, t, equations, mesh)
 end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -81,12 +81,12 @@ function SerreGreenNaghdiEquations1D(; bathymetry_type = bathymetry_variable,
 end
 
 """
-    initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D, mesh)
+    initial_condition_soliton(x, t, equations::SerreGreenNaghdiEquations1D, mesh)
 
-A soliton solution used for convergence tests in a periodic domain.
+A classical soliton solution of the Serre-Green-Naghdi equations. This can be used
+for convergence tests in a periodic domain, see [`initial_condition_convergence_test`](@ref).
 """
-function initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D,
-                                            mesh)
+function initial_condition_soliton(x, t, equations::SerreGreenNaghdiEquations1D, mesh)
     g = gravity(equations)
 
     # setup parameters data
@@ -104,6 +104,17 @@ function initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEqu
     eta = h + b
 
     return SVector(eta, v, D)
+end
+
+"""
+    initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D, mesh)
+
+A soliton solution used for convergence tests in a periodic domain. Same as
+[`initial_condition_soliton`](@ref) for the [`SerreGreenNaghdiEquations1D`](@ref).
+"""
+function initial_condition_convergence_test(x, t, equations::SerreGreenNaghdiEquations1D,
+                                            mesh)
+    return initial_condition_soliton(x, t, equations, mesh)
 end
 
 """


### PR DESCRIPTION
This makes it easier to use the same (physically relevant) initial condition for both the hyperbolic approximation of SGN and the original equations. With the current release, we would have to use `initial_condition_soliton` for the hyperbolic version and `initial_condition_convergence_test` for the original equations.