### PR TITLE
Fix bug when plotting with conversion function

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -55,13 +55,15 @@ end
     plot_title --> "$(get_name(equations)) at t = $(round(t, digits=5))"
     layout --> nsubplots
 
-    for i in 1:nsubplots
+    subplot = 0
+    for i in 1:nvars
         # Don't plot bathymetry in separate subplot
         names[i] in ["D", "b"] && continue
 
+        subplot += 1
         if plot_initial == true
             @series begin
-                subplot --> i
+                subplot --> subplot
                 linestyle := :solid
                 label --> "initial $(names[i])"
                 grid(semi), data_exact[i, :]
@@ -69,7 +71,7 @@ end
         end
 
         @series begin
-            subplot --> i
+            subplot --> subplot
             label --> names[i]
             xguide --> "x"
             yguide --> names[i]

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -58,7 +58,7 @@ end
     subplot = 0
     for i in 1:nvars
         # Don't plot bathymetry in separate subplot
-        names[i] in ["D", "b"] && continue
+        names[i] in ("D", "b") && continue
 
         subplot += 1
         if plot_initial == true


### PR DESCRIPTION
There was a bug when plotting the solution with a conversion function, which has more variables than the default `prim2phys`, where one frame was left empty.

```julia
julia> include("examples/hyperbolic_serre_green_naghdi_1d/hyperbolic_serre_green_naghdi_soliton.jl");
[...]
julia> plot(semi => sol, plot_initial = true, legend = :bottomleft, conversion = prim2prim)
```

gave before this PR:
<img width="600" height="400" alt="before" src="https://github.com/user-attachments/assets/4c16951c-abe2-415f-9474-baec698fb626" />
and after this PR gives:
<img width="600" height="400" alt="after" src="https://github.com/user-attachments/assets/4d6653f0-f14b-4f22-8f18-c36336e1d23d" />

Something similar also happened with `prim2cons` for instance.