### PR TITLE
Add dispersion relation for `KdVEquation1D`

### DIFF
--- a/docs/src/dispersion.md
+++ b/docs/src/dispersion.md
@@ -46,6 +46,10 @@ euler = EulerEquations1D(; gravity = g, eta0 = eta0)
 c_euler = wave_speed.(disp_rel, euler, k; normalize = true)
 plot(k, c_euler, label = "Euler", xlabel = "k", ylabel = "c / c_0", legend = :topright)
 
+kdv = KdVEquation1D(; gravity = g, eta0 = eta0, D = h0)
+c_kdv = wave_speed.(disp_rel, kdv, k; normalize = true)
+plot!(k, c_kdv, label = "KdV")
+
 bbm = BBMEquation1D(; gravity = g, eta0 = eta0, D = h0)
 c_bbm = wave_speed.(disp_rel, bbm, k; normalize = true)
 plot!(k, c_bbm, label = "BBM")

--- a/src/dispersion_relation.jl
+++ b/src/dispersion_relation.jl
@@ -70,6 +70,13 @@ function (disp_rel::LinearDispersionRelation)(equations::EulerEquations1D, k)
     return sqrt(g * k * tanh(h0 * k))
 end
 
+function (disp_rel::LinearDispersionRelation)(equations::KdVEquation1D, k)
+    eta0 = equations.eta0
+    h0 = disp_rel.ref_height
+    g = gravity(equations)
+    return sqrt(g * h0) * k * (1 + 1.5 * eta0 / h0) - 1 / 6 * h0^2 * k^3
+end
+
 function (disp_rel::LinearDispersionRelation)(equations::BBMEquation1D, k)
     eta0 = equations.eta0
     h0 = disp_rel.ref_height

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -448,6 +448,7 @@ end
     k = 2 * pi
     frequencies = [
         7.850990247314777,
+        -337.9894018087076,
         0.5660455316649682,
         0.5660455316649682,
         7.700912310929906,
@@ -455,6 +456,7 @@ end
     ]
     wave_speeds = [
         1.2495239060264087,
+        -53.79268401052861,
         0.09008894437955965,
         0.09008894437955965,
         1.2256382606017253,
@@ -462,6 +464,7 @@ end
     ]
 
     for (i, equations) in enumerate((EulerEquations1D(gravity = g),
+                                     KdVEquation1D(gravity = g),
                                      BBMEquation1D(gravity = g),
                                      BBMBBMEquations1D(gravity = g),
                                      SvaerdKalischEquations1D(gravity = g,


### PR DESCRIPTION
I noticed, we forgot to add the linear dispersion relation for the `KdVEquation1D`. However, something seems to be not quite right. Running the [example in the docs](https://numericalmathematics.github.io/DispersiveShallowWater.jl/stable/dispersion/) for `equations = kdv` gives me
![traveling_waves_kdv](https://github.com/user-attachments/assets/0180255a-e1d0-4aab-8fa1-59a9a951ea15)

For some reason, the numerical solution of the `KdVEquation1D` doesn't have the correct phase velocity. It is way too small (does is even move at all?). The speed of the green dot moves with the speed from the linear dispersion relation, which looks reasonable as it is of almost the same speed as the blue dot. The green wave should have the same speed (or in other words: The green dot should always stay on the maximum of the wave). I don't see why the numerical solution doesn't get the velocity right. Do you have any idea, @cwittens?