### PR TITLE
Fix coverallsapp GitHub action on macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,6 +77,10 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      # Workaround for https://github.com/coverallsapp/github-action/issues/264
+      - name: Trust Coveralls Homebrew tap (Homebrew 6 requirement)
+        if: runner.os == 'macOS'
+        run: brew trust coverallsapp/coveralls
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CI on MacOS is currently [failing](https://github.com/NumericalMathematics/DispersiveShallowWater.jl/actions/runs/28523381316/job/84553190895?pr=307) due to the coveralls GitHub action, see https://github.com/coverallsapp/github-action/issues/264. This applies the workaround suggested in that issue. Once https://github.com/coverallsapp/github-action/pull/265 is merged and released, this workaround can be reverted again.